### PR TITLE
feat: publish to NPM via DNT

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,0 +1,31 @@
+name: Publish NPM
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+          registry-url: "https://registry.npmjs.org"
+
+      - uses: denoland/setup-deno@v2
+
+      - name: Publish package
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+        run: |-
+          deno run -A dnt.ts
+          cd dnt
+          npm publish

--- a/dnt.ts
+++ b/dnt.ts
@@ -1,0 +1,54 @@
+// Bundle src/mod.ts into both ESM and CJS format.
+import { build } from "jsr:@deno/dnt@^0.41.3";
+
+import pkg from "./deno.json" with { type: "json" };
+
+await Deno.remove("./dnt", { recursive: true }).catch(() => {});
+
+await build({
+  entryPoints: ["./mod.ts"],
+  outDir: "./dnt",
+  shims: {
+    deno: {
+      test: true,
+    },
+  },
+  package: {
+    name: "@vicary/que-async",
+    version: pkg.version,
+    description: pkg.description,
+    author: "Vicary A. <vicary.archangel@member.mensa.org>",
+    license: "MIT",
+    repository: {
+      type: "git",
+      url: "git+https://github.com/jsr-que/async.git",
+    },
+    bugs: {
+      url: "https://github.com/jsr-que/async/issues",
+    },
+    keywords: [
+      "async",
+      "await",
+      "batch",
+      "chunk",
+      "generator",
+      "iterator",
+      "piping",
+      "promise",
+      "promises",
+      "stream",
+      "streaming",
+      "throttle",
+    ],
+    funding: {
+      type: "github",
+      url: "https://github.com/sponsors/vicary",
+    },
+  },
+  async postBuild() {
+    // steps to run after building and before running the tests
+    await Deno.copyFile("LICENSE", "dnt/LICENSE");
+    await Deno.copyFile("README.md", "dnt/README.md");
+  },
+  typeCheck: "both",
+});

--- a/lib/dnt-shim.ts
+++ b/lib/dnt-shim.ts
@@ -1,0 +1,24 @@
+/**
+ * @module lib/dnt-shim
+ *
+ * DNT unconditionally shims Promise.withResolvers because the standard is yet
+ * to name this version, e.g. ES2024, other than Latest. See PR #441.
+ */
+
+export interface PromiseWithResolvers<T> {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: any) => void;
+}
+
+export const promiseWithResolvers = <T>(): PromiseWithResolvers<T> => {
+  let resolve: (value: T | PromiseLike<T>) => void;
+  let reject: (reason?: any) => void;
+
+  const promise = new Promise<T>((resolve_, reject_) => {
+    resolve = resolve_;
+    reject = reject_;
+  });
+
+  return { promise, resolve: resolve!, reject: reject! };
+};


### PR DESCRIPTION
DNT is yet to support projects with upstream JSR dependencies.

Tracking issues:

1. denoland/dnt#437
2. denoland/dnt#438
3. denoland/dnt#441